### PR TITLE
Updates sep15

### DIFF
--- a/TrxSlackBot/Configuration/TrxSlackBotConfig.cs
+++ b/TrxSlackBot/Configuration/TrxSlackBotConfig.cs
@@ -3,6 +3,7 @@
 public class TrxSlackBotConfig
 {
     public string SlackWebhook { get; set; }
+    public string? HealthCheckWebhook { get; set; }
     public string? SlackBearerToken { get; set; }
     public string? TrxFile { get; set; }
     public string? DetailsLink { get; set; }

--- a/TrxSlackBot/Configuration/TrxSlackBotConfig.cs
+++ b/TrxSlackBot/Configuration/TrxSlackBotConfig.cs
@@ -7,7 +7,8 @@ public class TrxSlackBotConfig
     public string? TrxFile { get; set; }
     public string? DetailsLink { get; set; }
     public static string? ConfigMessageTitle { get; set; }
-    public string? MessageTitle => ReceiveMessageTitleFromConfig();
+    public bool SendDetailedMessageAsReply { get; set; }
+    public double SendDetailedMessageAsReplyWaitSecondsForMessage { get; set; }
     public bool SendOnlyIfRunHasFails { get; set; }
     public bool SendFailsAsReply { get; set; }
     public string? ChannelId { get; set; }
@@ -19,6 +20,8 @@ public class TrxSlackBotConfig
     public string? SnippedSlackFileName { get; set; }
     public string? SnippedSlackFilePostTitle { get; set; }
     public string? SnippedSlackFileType { get; set; }
+
+    public string? MessageTitle => ReceiveMessageTitleFromConfig();
 
     internal static TrxSlackBotConfig SlackBotConfigData = TrxSlackBotConfigService.GetTrxSlackBotConfig();
 

--- a/TrxSlackBot/Program.cs
+++ b/TrxSlackBot/Program.cs
@@ -11,12 +11,11 @@ public static class Program
         try
         {
             ConfigFile = args.Length != 0 ? args[0] : Path.Combine(Environment.CurrentDirectory, "trxSlackBotConfig.json");
+            await SlackCommunication.SendSlackMessage();
         }
         catch (Exception e)
         {
             Console.WriteLine(e.Message);
         }
-
-        await SlackCommunication.SendSlackMessage();
     }
 }

--- a/TrxSlackBot/TrxBot/SlackMessageBuilder.cs
+++ b/TrxSlackBot/TrxBot/SlackMessageBuilder.cs
@@ -12,7 +12,6 @@ namespace TrxSlackBot.TrxBot;
 public static class SlackMessageBuilder
 {
     public static int FailedTestCount { get; set; }
-
     private static readonly TrxSlackBotConfig SlackAndTrxConfig = TrxSlackBotConfigService.GetTrxSlackBotConfig();
     
     public static string GetDuration(this TrxTestRun trxTestRun)

--- a/TrxSlackBot/TrxBot/SlackMessageBuilder.cs
+++ b/TrxSlackBot/TrxBot/SlackMessageBuilder.cs
@@ -1,17 +1,18 @@
 ﻿using System.Globalization;
 using System.Text;
-using System.Threading;
 using SlackBotMessages;
-using SlackBotMessages.Enums;
 using SlackBotMessages.Models;
 using TrxSlackBot.Configuration;
 using TrxSlackBot.TrxFileModels;
 
 namespace TrxSlackBot.TrxBot;
 
+// ToDo: Restructure Methods with Parameters instead of Separate Methods that all do the same
+
 public static class SlackMessageBuilder
 {
     public static int FailedTestCount { get; set; }
+
     private static readonly TrxSlackBotConfig SlackAndTrxConfig = TrxSlackBotConfigService.GetTrxSlackBotConfig();
     
     public static string GetDuration(this TrxTestRun trxTestRun)
@@ -249,27 +250,6 @@ public static class SlackMessageBuilder
         }
     }
     
-    public static async Task SendFailedAsSlackReply()
-    {
-        try
-        {
-            var testRunData = TrxFileDeserializer.GetTrxTestRunFromConfig();
-            var webHookUrl = SlackAndTrxConfig.SlackWebhook;
-            if (string.IsNullOrEmpty(webHookUrl))
-            {
-                Console.WriteLine("No Slack WebHook in config");
-            }
-            var client = new SbmClient(webHookUrl);
-            var messageReply = await BuildFailedMessageReply(testRunData);
-            await client.SendAsync(messageReply);
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(e);
-            throw;
-        }
-    }
-
     public static string BuildFailedTestString(this TrxTestRun trxTestRun) => 
         string.Join("", trxTestRun.GetFailedTestNameAndError()
             .Select(x => $"{x.Key} \n{x.Value}").ToArray());

--- a/TrxSlackBot/TrxBot/TrxFileDeserializer.cs
+++ b/TrxSlackBot/TrxBot/TrxFileDeserializer.cs
@@ -18,9 +18,13 @@ public static class TrxFileDeserializer
         try
         {
             var rgx = new Regex("xmlns=\".*?\" ?");
-            var fileContent = rgx.Replace(File.ReadAllText(filePath), string.Empty);
-            var xDoc = XDocument.Parse(fileContent);
-            xDoc.Save(filePath);
+            var file = File.ReadAllText(filePath);
+            if (rgx.IsMatch(file))
+            {
+                var fileContent = rgx.Replace(file, string.Empty);
+                var xDoc = XDocument.Parse(fileContent);
+                xDoc.Save(filePath);
+            }
         }
         catch (Exception)
         {

--- a/TrxSlackBot/trxSlackBotConfig.json
+++ b/TrxSlackBot/trxSlackBotConfig.json
@@ -1,6 +1,7 @@
 {
   "TrxSlackBotConfig": {
     "slackWebhook": "",
+    "healthCheckWebhook": "",
     "slackBearerToken": "",
     "trxFile": "",
     "detailsLink": "",

--- a/TrxSlackBot/trxSlackBotConfig.json
+++ b/TrxSlackBot/trxSlackBotConfig.json
@@ -5,16 +5,18 @@
     "trxFile": "",
     "detailsLink": "",
     "ConfigMessageTitle": "",
+    "sendDetailedMessageAsReply": false,
+    "sendDetailedMessageAsReplyWaitSecondsForMessage": 0,
     "sendOnlyIfRunHasFails": false,
     "sendFailsAsReply": false,
     "channelId": "",
     "replyMessageTsId": "",
     "replyText": "",
-    "waitSecondsAfterMessageBeforeReply": 0,
+    "waitSecondsAfterMessageBeforeReply": 1,
     "sendFailsAsCodeSnipped": false,
     "snippedInitialComment": "",
     "snippedSlackFileName": "",
     "snippedSlackFilePostTitle": "",
-    "snippedSlackFileType": ""
+    "snippedSlackFileType": "xml"
   }
 }


### PR DESCRIPTION
Newly added Functionality
* Added second WebHook for reporting to separate channel
* Send a detailed report as reply to another message
* Only send a message to main channel if fails in a run are detected
* Send Failed tests as attachment snipped of defined code style for syntax highlighting

Minor Changes
* Renamed MessageTitle to ConfigMessage title for besser visibility
* Fixed issue when file was already serialized by added check
* Added waiter functions to wait defined seconds for a message to reply to